### PR TITLE
fix for calculateTestItemsStatus

### DIFF
--- a/src/realTimeReporter/utils.ts
+++ b/src/realTimeReporter/utils.ts
@@ -44,7 +44,8 @@ export const calculateTestItemStatus = (
     status = STATUSES.SKIPPED;
   } else if (currentTestItemResults.failed !== 0) {
     status = STATUSES.FAILED;
-    const assertionsResult = currentTestItemResults.assertions[0];
+    const assertionsResult =
+      currentTestItemResults.assertions[currentTestItemResults.assertions.length - 1];
 
     assertionsMessage = `${assertionsResult.fullMsg}<br/>${assertionsResult.stackTrace}`;
   } else {


### PR DESCRIPTION
fix for calculateTestItemsStatus as current implementation take first assertion item, but test can be failed in further steps